### PR TITLE
Add reply features

### DIFF
--- a/mio/core/utils.py
+++ b/mio/core/utils.py
@@ -1,6 +1,7 @@
 # Copyright mio authors & contributors <https://github.com/mirukana/mio>
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
+import html
 import re
 from inspect import isawaitable
 from io import StringIO
@@ -97,3 +98,12 @@ def comma_and_join(*items: str) -> str:
         return items[0]
 
     return "%s and %s" % (", ".join(items[:-1]), items[-1])
+
+
+def plain2html(text: str) -> str:
+    new = html.escape(text)
+    return new.replace("\n", "<br>").replace("\t", "&nbsp;" * 4)
+
+
+def html2plain(text: str) -> str:
+    return html.unescape(HTML_TAGS_RE.sub("", text.replace("<br>", "\n")))

--- a/mio/rooms/contents/messages.py
+++ b/mio/rooms/contents/messages.py
@@ -55,22 +55,22 @@ class Message(EventContent):
 
 @dataclass
 class Textual(Message):
+    aliases = {
+        "in_reply_to": ["m.relates_to", "m.in_reply_to", "event_id"],
+    }
+
     format:         Optional[str]     = None
     formatted_body: Optional[str]     = None
     in_reply_to:    Optional[EventId] = None
 
 
-    # Used to fill in_reply_to
+    # Needed for reply features
     @classmethod
     def from_dict(
         cls: Type[ContentT], data: DictS, parent: Optional["JSON"] = None,
     ) -> ContentT:
         textual    = super().from_dict(data, parent)
-        relates_to = data.get("m.relates_to")
 
-        if relates_to and relates_to.get("m.in_reply_to"):
-            in_reply_to = relates_to["m.in_reply_to"]["event_id"]
-            textual.in_reply_to = EventId(in_reply_to)
 
         return textual
 

--- a/mio/rooms/contents/messages.py
+++ b/mio/rooms/contents/messages.py
@@ -21,7 +21,7 @@ from ...core.files import (
 )
 from ...core.ids import MXC, EventId
 from ...core.transfer import TransferUpdateCallback
-from ...core.utils import HTML_TAGS_RE, DictS
+from ...core.utils import HTML_TAGS_RE
 
 if TYPE_CHECKING:
     from ...client import Client
@@ -65,17 +65,13 @@ class Textual(Message):
     in_reply_to:    Optional[EventId] = None
 
 
-    # Needed for reply features
-    @classmethod
-    def from_dict(
-        cls: Type[ContentT], data: DictS, parent: Optional["JSON"] = None,
-    ) -> ContentT:
-        textual               = super().from_dict(data, parent)
-        textual.stripped_body = textual.body
+    @property
+    def stripped_body(self):
+        stripped_body = self.body
 
         # Strip body if it's a reply, according to matrix spec
-        if textual.in_reply_to:
-            parts = textual.stripped_body.split("\n")
+        if self.in_reply_to:
+            parts = self.body.split("\n")
 
             while parts[0].startswith("> "):
                 parts = parts[1:]
@@ -83,9 +79,9 @@ class Textual(Message):
             if not parts[0]:  # Sometimes parts[0] is ""
                 parts = parts[1:]
 
-            textual.stripped_body = "\n".join(parts)
+            stripped_body = "\n".join(parts)
 
-        return textual
+        return stripped_body
 
 
     @classmethod

--- a/mio/rooms/contents/messages.py
+++ b/mio/rooms/contents/messages.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
 TexT     = TypeVar("TexT", bound="Textual")
 ContentT = TypeVar("ContentT", bound="EventContent")
 
+HTML_FORMAT:                    str      = "org.matrix.custom.html"
 THUMBNAIL_POSSIBLE_PIL_FORMATS: Set[str] = {"PNG", "JPEG"}
 THUMBNAIL_SIZE_MAX_OF_ORIGINAL: float    = 0.9  # must be <90% of orig size
 
@@ -78,12 +79,12 @@ class Textual(Message):
         if plaintext == html:
             return cls(plaintext)
 
-        return cls(plaintext, "org.matrix.custom.html", html)
+        return cls(plaintext, HTML_FORMAT, html)
 
 
     @property
     def html_no_reply_fallback(self) -> Optional[str]:
-        if self.format != "org.matrix.custom.html":
+        if self.format != HTML_FORMAT:
             return None
 
         soup     = BeautifulSoup(self.formatted_body, "html.parser")

--- a/mio/rooms/contents/messages.py
+++ b/mio/rooms/contents/messages.py
@@ -61,6 +61,7 @@ class Textual(Message):
 
     format:         Optional[str]     = None
     formatted_body: Optional[str]     = None
+    stripped_body:  Optional[str]     = None
     in_reply_to:    Optional[EventId] = None
 
 
@@ -69,8 +70,20 @@ class Textual(Message):
     def from_dict(
         cls: Type[ContentT], data: DictS, parent: Optional["JSON"] = None,
     ) -> ContentT:
-        textual    = super().from_dict(data, parent)
+        textual               = super().from_dict(data, parent)
+        textual.stripped_body = textual.body
 
+        # Strip body if it's a reply, according to matrix spec
+        if textual.in_reply_to:
+            parts = textual.stripped_body.split("\n")
+
+            while parts[0].startswith("> "):
+                parts = parts[1:]
+
+            if not parts[0]:  # Sometimes parts[0] is ""
+                parts = parts[1:]
+
+            textual.stripped_body = "\n".join(parts)
 
         return textual
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -37,3 +37,6 @@ ignore_missing_imports = True
 
 [mypy-PIL.*]
 ignore_missing_imports = True
+
+[mypy-bs4.*]
+ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         aiohttp           >= 3.7.3,  < 4
         aiopath           >= 0.5.4,  < 0.6
         backoff           >= 1.10.0, < 2
+        beautifulsoup4    >= 4.9.3,  < 5
         loguru            >= 0.5.3,  < 0.6
         pycryptodomex     >= 3.10.1, < 4
         python-magic      >= 0.4.22, < 0.5

--- a/tests/test_rooms/test_contents.py
+++ b/tests/test_rooms/test_contents.py
@@ -71,6 +71,16 @@ def test_textual_same_html_plaintext():
     assert text.formatted_body is None
 
 
+def test_textual_no_reply_fallback():
+    assert Text("plain").html_no_reply_fallback is None
+
+    reply = Text.from_html("<mx-reply>...</mx-reply><b>foo</b>")
+    assert reply.html_no_reply_fallback == "<b>foo</b>"
+
+    not_reply = Text.from_html("<b>foo</b>")
+    assert not_reply.html_no_reply_fallback == "<b>foo</b>"
+
+
 def test_encrypted_file_init():
     create_encrypted_file(key_operations=["encrypt", "decrypt"])
 

--- a/tests/test_rooms/test_contents.py
+++ b/tests/test_rooms/test_contents.py
@@ -11,9 +11,9 @@ from pytest import mark, raises
 from mio.client import Client
 from mio.core.ids import MXC
 from mio.rooms.contents.messages import (
-    THUMBNAIL_POSSIBLE_PIL_FORMATS, THUMBNAIL_SIZE_MAX_OF_ORIGINAL, Audio,
-    Emote, EncryptedFile, File, Image, Media, Notice, Text, Thumbnailable,
-    Video,
+    HTML_FORMAT, THUMBNAIL_POSSIBLE_PIL_FORMATS,
+    THUMBNAIL_SIZE_MAX_OF_ORIGINAL, Audio, Emote, EncryptedFile, File, Image,
+    Media, Notice, Text, Thumbnailable, Video,
 )
 from mio.rooms.room import Room
 
@@ -53,14 +53,14 @@ async def test_textual_from_html(room: Room):
         content = room.timeline[-1].content
         assert isinstance(content, kind)
         assert content.body == "abc"
-        assert content.format == "org.matrix.custom.html"
+        assert content.format == HTML_FORMAT
         assert content.formatted_body == "<p>abc</p>"
 
 
 def test_textual_from_html_manual_plaintext():
     text = Text.from_html("<p>abc</p>", plaintext="123")
     assert text.body == "123"
-    assert text.format == "org.matrix.custom.html"
+    assert text.format == HTML_FORMAT
     assert text.formatted_body == "<p>abc</p>"
 
 


### PR DESCRIPTION
Related to #18

- [x] Get event reply information (in event's content, `m.relates_to -> m.in_reply_to`)
- [x] `Text`/`Notice` event helper for creating a reply (e.g. `Text.replies_to(event: TimelineEvent)`)
- [x] `Text`/`Notice` event helper/attribute body text without reply body
- [x] Tests